### PR TITLE
Directly export SearchModifiers

### DIFF
--- a/howlongtobeatpy/howlongtobeatpy/__init__.py
+++ b/howlongtobeatpy/howlongtobeatpy/__init__.py
@@ -1,2 +1,3 @@
 from .HowLongToBeat import HowLongToBeat
 from .HowLongToBeatEntry import HowLongToBeatEntry
+from .HTMLRequests import SearchModifiers


### PR DESCRIPTION
This make it easier to find the Search Modifiers enum.   Otherwise, the user has to import directly, like this:
```python
from howlongtobeatpy.HTMLRequests import SearchModifiers
```

The new syntax can be:
```python
from howlongtobeat import HowLongToBeat, SearchModifiers
```